### PR TITLE
Avoid hard-coding Qt version number in settings dialog

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -114,7 +114,9 @@ void Settings::showAbout()
                   "<p align='center' style=' margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; "
                   "-qt-block-indent:0; text-indent:0px;'>Website: https://ktechpit.com</p>"
                   "<p align='center' style=' margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; "
-                  "-qt-block-indent:0; text-indent:0px;'>Runtime: Qt 5.5.1</p>"
+                  "-qt-block-indent:0; text-indent:0px;'>Runtime: Qt "
+                  QT_VERSION_STR
+                  "</p>"
                   "<p align='center' style=' margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; "
                   "-qt-block-indent:0; text-indent:0px;'>Version: " +
                   QApplication::applicationVersion() +


### PR DESCRIPTION
This simple change ensures the correct Qt version number is always displayed.