### PR TITLE
Hide "rate" button for non-snapcraft builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,9 @@ parts:
      source: src/
      plugin: qmake
      qt-version: qt5
+     # TODO: Change this to qmake-parameters when updating to from core18 to core20
+     options:
+       - "DEFINES+=COLORPICKER_SNAPCRAFT_BUILD"
      override-build: |
             snapcraftctl build
             sed -i 's|Icon=.*|Icon=${SNAP}/meta/gui/icon.png|g' ${SNAPCRAFT_PART_SRC}/color-picker.desktop

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -78,11 +78,13 @@ void Settings::on_girhubPushButton_clicked()
     QDesktopServices::openUrl(QUrl("https://github.com/keshavbhatt/ColorPicker"));
 }
 
+#ifdef COLORPICKER_SNAPCRAFT_BUILD
 void Settings::on_ratePushButton_clicked()
 {
     QDesktopServices::openUrl(QUrl("snap://color-picker"));
 }
 
+#endif
 void Settings::on_themeComboBox_currentIndexChanged(const QString &arg1)
 {
     emit themeChanged(arg1);

--- a/src/settings.h
+++ b/src/settings.h
@@ -47,8 +47,10 @@ class Settings : public QWidget
 
     void on_girhubPushButton_clicked();
 
+#ifdef COLORPICKER_SNAPCRAFT_BUILD
     void on_ratePushButton_clicked();
 
+#endif
     void on_themeComboBox_currentIndexChanged(const QString &arg1);
 
     void on_advance_toggled(bool checked);


### PR DESCRIPTION
It doesn't make sense to show the Rate button for non-snapcraft builds
because the button won't be functional. It is therefore only likely to
confuse users.