### PR TITLE
Fix segfault when LTO is enabled

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -50,7 +50,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         else if (themeName.contains("System"))
         {
             settings.setValue("theme", themeName);
-            qApp->setStyleSheet("");
+            this->setStyleSheet("");
         }
         foreach (QSpinBox *spinbox, colorDialog->findChildren<QSpinBox *>())
         {
@@ -237,7 +237,7 @@ void MainWindow::setStyle(QString fname)
         qWarning("Unable to open file");
         return;
     }
-    qApp->setStyleSheet(styleSheet.readAll());
+    this->setStyleSheet(styleSheet.readAll());
     styleSheet.close();
 }
 


### PR DESCRIPTION
On all Ubuntu releases ColorPicker ends in a segfault with a coredump.
The issue is not seen in Debian as LTO is disabled in Debian.

Closes: https://github.com/keshavbhatt/ColorPicker/issues/23